### PR TITLE
Added an API to allow users to read extensions not supported/needed by webpki

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -172,9 +172,6 @@ fn remember_extension<'a>(
     // all policy-related stuff. We assume that the policy-related extensions
     // are not marked critical.
 
-    // id-ce 2.5.29
-    static ID_CE: [u8; 2] = oid![2, 5, 29];
-
     let mut ret = Ok(Understood::Yes);
 
     let extension_id = &*extn_id.as_slice_less_safe();

--- a/src/der.rs
+++ b/src/der.rs
@@ -153,9 +153,3 @@ pub fn time_choice<'a>(input: &mut untrusted::Reader<'a>) -> Result<time::Time, 
     })
 }
 
-macro_rules! oid {
-    ( $first:expr, $second:expr, $( $tail:expr ),* ) =>
-    (
-        [(40 * $first) + $second, $( $tail ),*]
-    )
-}

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -143,8 +143,8 @@ impl<'a> EndEntityCert<'a> {
     /// Retrieves the raw extensions that were found in the certificate but were
     /// not recognized by the webpki library. These could be custom extensions
     /// or standard extensions not relevant to how the library operates
-    pub fn unrecognized_extensions(&self) -> std::collections::HashMap<&'a[u8], untrusted::Input<'a>> {
-        return self.inner.unrecognized_extensions.clone();
+    pub fn unrecognized_extensions(&self) -> &std::collections::HashMap<&'a[u8], untrusted::Input<'a>> {
+        return &self.inner.unrecognized_extensions;
     }
 
     /// Verifies that the end-entity certificate is valid for use by a TLS

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -140,6 +140,13 @@ impl<'a> EndEntityCert<'a> {
         })
     }
 
+    /// Retrieves the raw extensions that were found in the certificate but were
+    /// not recognized by the webpki library. These could be custom extensions
+    /// or standard extensions not relevant to how the library operates
+    pub fn unrecognized_extensions(&self) -> std::collections::HashMap<&'a[u8], untrusted::Input<'a>> {
+        return self.inner.unrecognized_extensions.clone();
+    }
+
     /// Verifies that the end-entity certificate is valid for use by a TLS
     /// server.
     ///


### PR DESCRIPTION
Previously, the library only parsed extensions that it needed and knew what to do with. This prevented the use of custom certificates that the calling library/program knows what to do with. 

I added a hash map that contains all of the extensions (in raw form) that webpki didn't have any use for. This hash map can be retrieved and the caller can do what it wants with them.